### PR TITLE
get tests passing with new asyncio selector_loop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,15 @@
 
 dist: xenial
 language: python
-matrix:
-    fast_finish: true
 addons:
-  apt: 
+  apt:
     packages:
       - libgnutls-dev
 
 # For a list of available versions, run
 #     aws s3 ls s3://travis-python-archives/binaries/ubuntu/16.04/x86_64/
 jobs:
+  fast_finish: true
   include:
     # 3.5.2 is interesting because it's the version in ubuntu 16.04, and due to python's
     # "provisional feature" rules there are significant differences between patch

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -243,7 +243,7 @@ class BaseAsyncIOLoop(IOLoop):
         self,
         executor: Optional[concurrent.futures.Executor],
         func: Callable[..., _T],
-        *args: Any,
+        *args: Any
     ) -> Awaitable[_T]:
         return self.asyncio_loop.run_in_executor(executor, func, *args)
 

--- a/tornado/platform/asyncio.py
+++ b/tornado/platform/asyncio.py
@@ -35,10 +35,16 @@ from typing import Any, TypeVar, Awaitable, Callable, Union, Optional
 if typing.TYPE_CHECKING:
     from typing import Set, Dict, Tuple  # noqa: F401
 
+try:
+    from typing import Protocol
+except ImportError:
+    # typing.Protocol is new in 3.8
+    from typing import Type as Protocol
+
 _T = TypeVar("_T")
 
 
-class _HasFileno(typing.Protocol):
+class _HasFileno(Protocol):
     def fileno(self) -> int:
         pass
 
@@ -71,7 +77,7 @@ class BaseAsyncIOLoop(IOLoop):
         # as windows where the default event loop does not implement these methods.
         self.selector_loop = asyncio_loop
         if hasattr(asyncio, "ProactorEventLoop") and isinstance(
-            asyncio_loop, asyncio.ProactorEventLoop
+            asyncio_loop, asyncio.ProactorEventLoop  # type: ignore
         ):
             # Ignore this line for mypy because the abstract method checker
             # doesn't understand dynamic proxies.

--- a/tornado/test/__init__.py
+++ b/tornado/test/__init__.py
@@ -1,8 +1,0 @@
-import asyncio
-import sys
-
-# Use the selector event loop on windows. Do this in tornado/test/__init__.py
-# instead of runtests.py so it happens no matter how the test is run (such as
-# through editor integrations).
-if sys.platform == "win32" and hasattr(asyncio, "WindowsSelectorEventLoopPolicy"):
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # type: ignore

--- a/tornado/test/httpclient_test.py
+++ b/tornado/test/httpclient_test.py
@@ -500,10 +500,12 @@ X-XSS-Protection: 1;
                 stream.close()
 
             netutil.add_accept_handler(sock, accept_callback)  # type: ignore
-            resp = self.fetch("http://127.0.0.1:%d/" % port)
-            resp.rethrow()
-            self.assertEqual(resp.headers["X-XSS-Protection"], "1; mode=block")
-            self.io_loop.remove_handler(sock.fileno())
+            try:
+                resp = self.fetch("http://127.0.0.1:%d/" % port)
+                resp.rethrow()
+                self.assertEqual(resp.headers["X-XSS-Protection"], "1; mode=block")
+            finally:
+                self.io_loop.remove_handler(sock.fileno())
 
     def test_304_with_content_length(self):
         # According to the spec 304 responses SHOULD NOT include

--- a/tornado/test/iostream_test.py
+++ b/tornado/test/iostream_test.py
@@ -943,6 +943,7 @@ class TestIOStreamStartTLS(AsyncTestCase):
             self.server_stream.close()
         if self.client_stream is not None:
             self.client_stream.close()
+        self.io_loop.remove_handler(self.listener.fileno())
         self.listener.close()
         super(TestIOStreamStartTLS, self).tearDown()
 

--- a/tornado/test/simple_httpclient_test.py
+++ b/tornado/test/simple_httpclient_test.py
@@ -745,7 +745,7 @@ class MaxHeaderSizeTest(AsyncHTTPTestCase):
         self.assertEqual(response.body, b"ok")
 
     def test_large_headers(self):
-        with ExpectLog(gen_log, "Unsatisfiable read"):
+        with ExpectLog(gen_log, "Unsatisfiable read", level=logging.INFO):
             with self.assertRaises(UnsatisfiableReadError):
                 self.fetch("/large", raise_error=True)
 


### PR DESCRIPTION
typing.Protocol is new in Python 3.8

and ignore type on asyncio.ProactorEventLoop because it's not available on non-Windows. Not sure if there's another way to do that.